### PR TITLE
Support multiple recipients for forward.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
-    inputs:
-      test_branch:
-        description: 'Branch to test'
-        required: false
 
 jobs:
   test:

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -200,10 +200,15 @@ def lambda_handler(event, context):
             # 転送用メールを作成
             forwarded_message = create_forwarded_message(original_message, original_recipient, forward_to)
 
+            # # 送信時にカンマで分割してリスト化
+            # forward_to_list = [addr.strip() for addr in forward_to.split(',')]
+
             # SESでメールを送信
             response = ses_client.send_raw_email(
                 Source=forwarded_message['From'],
-                Destinations=[forward_to],
+                # create_forwarded_message 関数で、MIMEヘッダ 'To' に指定されているので、重複指定を避ける
+                # MIMEヘッダでは指定していないアドレスを送信先に含める場合には、Destinations にリストで指定する
+                # Destinations=forward_to_list,
                 RawMessage={'Data': forwarded_message.as_string()}
             )
 


### PR DESCRIPTION
## 背景
転送設定を定義する環境変数 `MAIL_FORWARDS` は、元のメールの宛先アドレスをkeyとして、転送先アドレスを定義します。
特定の宛先アドレスに対して、転送先アドレスを複数定義する場合、メールヘッダーの複数アドレス表記と同様にカンマ区切りで記述します。

## 問題
転送メールの送信で転送先アドレスをSESに渡す際、`ses_client.send_raw_email` の引数 `Destinations` はメールアドレスをリストで受け取ります。
転送先アドレスが1件の場合はそのまま渡しても動作しますが、複数件の場合にはリストで渡す必要があります。
複数件のメールアドレスがカンマ区切りで記述された形式で渡すとエラーになります。

## 対応内容
- `ses_client.send_raw_email` の呼び出し前に、転送先アドレスを（件数に依らず）リスト化してから処理を進める様に改善しました

しかし、下記の対応により、上記の対応は無効になりました。

- 転送メールを作成するなかで、MIMEヘッダ（Toヘッダ）に送信先を指定しているので、`ses_client.send_raw_email` の引数 `Destinations` にも指定すると重複指定になってしまうことから、`Destinations` への指定自体を廃止しました
  - なお、MIMEヘッダで指定されていない宛先を指定する場合には `Destinations` で指定できるものと思われます

----
その他、GitHub CI 向けの設定で、手動でCI実行するための設定 `workflow_dispatch` に、余計な追加設定は不要そうだったので削除しました。